### PR TITLE
mr_rqt: add moc_run patch

### DIFF
--- a/hydro/mr_rqt/PKGBUILD
+++ b/hydro/mr_rqt/PKGBUILD
@@ -29,8 +29,15 @@ depends=(${ros_depends[@]})
 
 _tag=release/hydro/mr_rqt/${pkgver}-${_pkgver_patch}
 _dir=mr_rqt
-source=("${_dir}"::"git+https://github.com/cogniteam/mr_teleoperator-release"#tag=${_tag})
-md5sums=('SKIP')
+source=("${_dir}"::"git+https://github.com/cogniteam/mr_teleoperator-release"#tag=${_tag}
+        "q_moc_run.patch")
+md5sums=('SKIP'
+         '317a3f2db5ee8e6b35ca42e6f063baaf')
+
+prepare() {
+  cd ${_dir}
+  patch -p1 -i ${srcdir}/q_moc_run.patch
+}
 
 build() {
   # Use ROS environment variables

--- a/hydro/mr_rqt/q_moc_run.patch
+++ b/hydro/mr_rqt/q_moc_run.patch
@@ -1,0 +1,21 @@
+diff --git a/include/mr_rqt/MrRqt.h b/include/mr_rqt/MrRqt.h
+index 0d5b45d..354723f 100644
+--- a/include/mr_rqt/MrRqt.h
++++ b/include/mr_rqt/MrRqt.h
+@@ -32,10 +32,12 @@
+ #include <iostream>
+ #include <set>
+ 
+-#include <boost/foreach.hpp>
+-#include <boost/date_time.hpp>
+-#include <boost/thread.hpp>
+-#include <boost/algorithm/string.hpp>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
++# include <boost/foreach.hpp>
++# include <boost/date_time.hpp>
++# include <boost/thread.hpp>
++# include <boost/algorithm/string.hpp>
++#endif
+ 
+ #include <ros/ros.h>
+ #include <std_msgs/String.h>


### PR DESCRIPTION
Fixes build issues with mr_rqt package and newer versions of boost.

The same patch will also be sent upstream.
